### PR TITLE
show_latest_message_in_side_bar

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,12 @@ class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
   has_many :messages
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/devise/shared/_side_bar.html.haml
+++ b/app/views/devise/shared/_side_bar.html.haml
@@ -17,4 +17,4 @@
           .group__name
             = group.name
           .group__message
-            メッセージはまだありません。
+            = group.show_last_message

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -8,13 +8,7 @@
         %p Edit
         =link_to "#" 
   .main-body
-    .main-userbox
-      .main-user
-        test-user
-      .main-time
-        2019/11/21(thr) 00:00:00
-    .main-message
-      こんにちは
+    = render @messages
   .main-bottom
     .main-message
       = form_for [@group,@message] do |f|

--- a/app/views/messages/_messages.html.haml
+++ b/app/views/messages/_messages.html.haml
@@ -1,0 +1,12 @@
+.main-userbox
+  .main-user
+    = message.user.name
+  .main-time
+    = message.created_at.strftime("%Y/%m/%d %H:%M")
+.main-message
+  /*元々main-messageクラスだけだったが以下のクラスを追加*/
+  /*なのであとでそれに合うよう変更*/
+  - if message.content.present?
+      %p.main-message__content
+        = message.content
+    = image_tag message.image.url, class: 'main-message__image' if message.image.present?


### PR DESCRIPTION
#what
サイドバーのグループ一覧に最新のメッセージを表示する。

#why
どのグループで何が表示されているかを一目でわかりやすくするため。